### PR TITLE
Duy/neteng 10948

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/S3BucketStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/S3BucketStorage.java
@@ -100,7 +100,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 public class S3BucketStorage implements StorageProvider {
   private static final Logger LOGGER = LogManager.getLogger(S3BucketStorage.class);
 
-  @VisibleForTesting static final Duration GC_SKEW_ALLOWANCE = Duration.ofMinutes(1440L);
+  @VisibleForTesting static final Duration GC_SKEW_ALLOWANCE = Duration.ofMinutes(10L);
   private static final String ID_EXTENSION = ".id";
   private static final String SUFFIX_LOG_FILE = ".log";
   private static final String SUFFIX_ANSWER_JSON_FILE = ".json";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/S3BucketStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/S3BucketStorage.java
@@ -100,7 +100,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 public class S3BucketStorage implements StorageProvider {
   private static final Logger LOGGER = LogManager.getLogger(S3BucketStorage.class);
 
-  @VisibleForTesting static final Duration GC_SKEW_ALLOWANCE = Duration.ofMinutes(10L);
+  @VisibleForTesting static final Duration GC_SKEW_ALLOWANCE = Duration.ofMinutes(1440L);
   private static final String ID_EXTENSION = ".id";
   private static final String SUFFIX_LOG_FILE = ".log";
   private static final String SUFFIX_ANSWER_JSON_FILE = ".json";


### PR DESCRIPTION
Currently, every time the batfish application boots up, it will run its garbage collection function. The garbage collection will check if the age of the snapshot in the s3 bucket is older than 10mins, if so it will delete the snapshot. 

So every time batfish redeploys, there will a certain amount of time that there will be no snapshots to be used until the snapshot tool runs or is manually run and loads a new snapshot.

I have changed the age time from 10mins to 24 hours. This will ensure there is always a present snapshot on the s3 bucket for batfish to use. As the snapshot tool loads a new snapshot every day at 12:00.